### PR TITLE
Fix mismatched file names

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -40,6 +40,7 @@ We provide a `.deb` file for Debian and Ubuntu. To install it, download `buckaro
 Alternatively, you can use the command-line:
 
 .. code-block:: bash
+
    deb_url='https://github.com/LoopPerfect/buckaroo/releases/download/v1.3.1/buckaroo_1.3.1_amd64.deb' 
    wget "$deb_url"
    sudo dpkg -i $(basename "$deb_url")

--- a/installation.rst
+++ b/installation.rst
@@ -40,9 +40,9 @@ We provide a `.deb` file for Debian and Ubuntu. To install it, download `buckaro
 Alternatively, you can use the command-line:
 
 .. code-block:: bash
-
-   wget https://github.com/LoopPerfect/buckaroo/releases/download/v1.3.1/buckaroo_1.3.1_amd64.deb
-   sudo dpkg -i buckaroo_1.3.0_all.deb
+   deb_url='https://github.com/LoopPerfect/buckaroo/releases/download/v1.3.1/buckaroo_1.3.1_amd64.deb' 
+   wget "$deb_url"
+   sudo dpkg -i $(basename "$deb_url")
 
 Finally, fetch the cookbook with:
 


### PR DESCRIPTION
The original documentation had a mismatch between the file fetched by wget and the file that dpkg was attempting to install.